### PR TITLE
auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Directories
 .DS_Store
+
+# Files
+config.yml

--- a/client/client.go
+++ b/client/client.go
@@ -21,6 +21,7 @@ const (
 
 var (
 	ErrClientNotFound = errors.New("client not found in context")
+	ErrTokenEmpty     = errors.New("token is empty; please run `concord auth` or set the GITHUB_TOKEN environment variable")
 )
 
 type Client struct {
@@ -31,11 +32,15 @@ type Client struct {
 }
 
 func New(ctx context.Context, tkn string) (*Client, error) {
+	if tkn == "" {
+		return nil, ErrTokenEmpty
+	}
+
 	pool := trust.New()
 
 	certs, err := pool.CACerts()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create cert pool: %v\n", err.Error())
+		return nil, fmt.Errorf("failed to create cert pool: %w", err)
 	}
 
 	httpClient := &http.Client{

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"github.com/gomicro/trust"
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+)
+
+func init() {
+	rootCmd.AddCommand(NewAuthCmd(os.Stdout, openBrowser))
+}
+
+const (
+	state = "5bbeb48d-8f22-407a-9586-6da897ebffac"
+)
+
+var (
+	reapprove    bool
+	clientID     string
+	clientSecret string
+)
+
+func NewAuthCmd(out io.Writer, browserFunc func(string) error) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "auth with github",
+		Long:  `authorize concord against github`,
+		RunE:  authRun(browserFunc),
+	}
+
+	cmd.Flags().BoolVarP(&reapprove, "force", "f", false, "force concord to reauth")
+	cmd.SetOut(out)
+
+	return cmd
+}
+
+func authRun(browserFunc func(string) error) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			cmd.SilenceUsage = true
+			return fmt.Errorf("auth: %w", err)
+		}
+
+		port := listener.Addr().(*net.TCPAddr).Port
+
+		pool := trust.New()
+
+		certs, err := pool.CACerts()
+		if err != nil {
+			cmd.SilenceUsage = true
+			return fmt.Errorf("auth: %w", err)
+		}
+
+		httpClient := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{RootCAs: certs},
+			},
+		}
+
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
+
+		conf := &oauth2.Config{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			Scopes:       []string{"repo"},
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  "https://github.com/login/oauth/authorize",
+				TokenURL: "https://github.com/login/oauth/access_token",
+			},
+			RedirectURL: fmt.Sprintf("http://localhost:%v/auth", port),
+		}
+
+		token := make(chan string)
+
+		go startServer(ctx, listener, conf, token)
+
+		var opts []oauth2.AuthCodeOption
+		if reapprove {
+			opts = []oauth2.AuthCodeOption{oauth2.AccessTypeOffline, oauth2.ApprovalForce}
+		} else {
+			opts = []oauth2.AuthCodeOption{oauth2.AccessTypeOffline}
+		}
+
+		url := conf.AuthCodeURL(state, opts...)
+
+		err = browserFunc(url)
+		if err != nil {
+			cmd.SilenceUsage = true
+			return fmt.Errorf("auth: %w", err)
+		}
+
+		//tkn := <-token
+		close(token)
+
+		/*
+			c, err := config.ParseFromFile()
+			if err != nil {
+				cmd.SilenceUsage = true
+				return fmt.Errorf("auth: %w", err)
+			}
+
+			c.Github.Token = tkn
+
+			err = c.WriteFile()
+			if err != nil {
+				cmd.SilenceUsage = true
+				return fmt.Errorf("auth: %w", err)
+			}
+		*/
+
+		return nil
+	}
+}
+
+func startServer(ctx context.Context, listener net.Listener, conf *oauth2.Config, token chan string) {
+	http.HandleFunc("/auth", authHandler(ctx, conf, token))
+
+	srv := &http.Server{}
+
+	go func() {
+		<-ctx.Done()
+		err := srv.Shutdown(ctx)
+		if err != nil {
+			fmt.Printf("Error shutting down server: %s", err)
+			os.Exit(1)
+		}
+	}()
+
+	err := srv.Serve(listener)
+	if err != nil {
+		fmt.Printf("Error: %s", err)
+		os.Exit(1)
+	}
+}
+
+func authHandler(ctx context.Context, conf *oauth2.Config, token chan string) func(w http.ResponseWriter, req *http.Request) {
+	return func(w http.ResponseWriter, req *http.Request) {
+		code := req.URL.Query().Get("code")
+		rstate := req.URL.Query().Get("state")
+
+		if rstate != state {
+			fmt.Println("bad response from oauth server")
+			os.Exit(1)
+		}
+
+		tok, err := conf.Exchange(ctx, code)
+		if err != nil {
+			fmt.Printf("errored exchanging token: %s", err)
+			os.Exit(1)
+		}
+
+		body := `<html>
+	<body>
+		<h1>Config file updated, you can close this window.</h1>
+	</body>
+</html>`
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(body)) //nolint
+		token <- tok.AccessToken
+	}
+}
+
+func openBrowser(url string) error {
+	ctx := context.Background()
+
+	switch runtime.GOOS {
+	case "linux":
+		err := exec.CommandContext(ctx, "xdg-open", url).Start()
+		return fmt.Errorf("open browser: linux: %w", err)
+	case "windows":
+		err := exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", url).Start()
+		return fmt.Errorf("open browser: windows: %w", err)
+	case "darwin":
+		err := exec.CommandContext(ctx, "open", url).Start()
+		return fmt.Errorf("open browser: darwin: %w", err)
+	default:
+		return fmt.Errorf("open browser: unsupported platform")
+	}
+}

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -180,17 +180,29 @@ func authHandler(ctx context.Context, conf *oauth2.Config, token chan string) fu
 func openBrowser(url string) error {
 	ctx := context.Background()
 
+	var perr error
 	switch runtime.GOOS {
 	case "linux":
 		err := exec.CommandContext(ctx, "xdg-open", url).Start()
-		return fmt.Errorf("open browser: linux: %w", err)
+		if err != nil {
+			perr = fmt.Errorf("open browser: linux: %w", err)
+		}
+
 	case "windows":
 		err := exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", url).Start()
-		return fmt.Errorf("open browser: windows: %w", err)
+		if perr != nil {
+			perr = fmt.Errorf("open browser: windows: %w", err)
+		}
+
 	case "darwin":
 		err := exec.CommandContext(ctx, "open", url).Start()
-		return fmt.Errorf("open browser: darwin: %w", err)
+		if perr != nil {
+			perr = fmt.Errorf("open browser: darwin: %w", err)
+		}
+
 	default:
-		return fmt.Errorf("open browser: unsupported platform")
+		perr = fmt.Errorf("open browser: unsupported platform")
 	}
+
+	return perr
 }

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 
 	"github.com/gomicro/trust"
 	"github.com/spf13/cobra"
@@ -25,7 +26,6 @@ const (
 )
 
 var (
-	reapprove    bool
 	clientID     string
 	clientSecret string
 )
@@ -38,7 +38,7 @@ func NewAuthCmd(out io.Writer, browserFunc func(string) error) *cobra.Command {
 		RunE:  authRun(browserFunc),
 	}
 
-	cmd.Flags().BoolVarP(&reapprove, "force", "f", false, "force concord to reauth")
+	cmd.Flags().BoolP("reauth", "r", false, "force concord to reauth")
 	cmd.SetOut(out)
 
 	return cmd
@@ -89,7 +89,7 @@ func authRun(browserFunc func(string) error) func(*cobra.Command, []string) erro
 		go startServer(ctx, listener, conf, token)
 
 		var opts []oauth2.AuthCodeOption
-		if reapprove {
+		if strings.EqualFold(cmd.Flag("reauth").Value.String(), "true") {
 			opts = []oauth2.AuthCodeOption{oauth2.AccessTypeOffline, oauth2.ApprovalForce}
 		} else {
 			opts = []oauth2.AuthCodeOption{oauth2.AccessTypeOffline}

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/gomicro/concord/config"
 	"github.com/gomicro/trust"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
@@ -106,24 +107,22 @@ func authRun(browserFunc func(string) error) func(*cobra.Command, []string) erro
 			return fmt.Errorf("auth: %w", err)
 		}
 
-		//tkn := <-token
+		tkn := <-token
 		close(token)
 
-		/*
-			c, err := config.ParseFromFile()
-			if err != nil {
-				cmd.SilenceUsage = true
-				return fmt.Errorf("auth: %w", err)
-			}
+		c, err := config.ParseFromFile()
+		if err != nil {
+			cmd.SilenceUsage = true
+			return fmt.Errorf("auth: %w", err)
+		}
 
-			c.Github.Token = tkn
+		c.Github.Token = tkn
 
-			err = c.WriteFile()
-			if err != nil {
-				cmd.SilenceUsage = true
-				return fmt.Errorf("auth: %w", err)
-			}
-		*/
+		err = c.WriteToFile()
+		if err != nil {
+			cmd.SilenceUsage = true
+			return fmt.Errorf("auth: %w", err)
+		}
 
 		return nil
 	}

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -76,7 +76,10 @@ func authRun(browserFunc func(string) error) func(*cobra.Command, []string) erro
 		conf := &oauth2.Config{
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
-			Scopes:       []string{"repo"},
+			Scopes: []string{
+				"repo",      // Grants full access to public and private repositories including read and write access to code, commit statuses, repository invitations, collaborators, deployment statuses, and repository webhooks.
+				"admin:org", // Fully manage the organization and its teams, projects, and memberships.
+			},
 			Endpoint: oauth2.Endpoint{
 				AuthURL:  "https://github.com/login/oauth/authorize",
 				TokenURL: "https://github.com/login/oauth/access_token",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/gomicro/concord/client"
+	"github.com/gomicro/concord/config"
 	"github.com/gomicro/concord/report"
 	"github.com/spf13/cobra"
 )
@@ -28,12 +30,22 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
-	// TODO: Read token from config file or env, with env taking precedence
+	c, err := config.ParseFromFile()
+	if err != nil {
+		fmt.Printf("Error: %s\n", err.Error())
+		os.Exit(1)
+	}
+
 	tkn := os.Getenv("GITHUB_TOKEN")
 
-	ctx := client.WithClient(context.Background(), tkn)
+	if tkn != "" {
+		c.Github.Token = tkn
+	}
+
+	ctx := client.WithClient(context.Background(), c.Github.Token)
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
+		fmt.Printf("Error: %s\n", err.Error())
 		os.Exit(1)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ctxKey string
+
+const (
+	ctxKeyConfig ctxKey = "config"
+)
+
+var (
+	ErrConfigNotFound = fmt.Errorf("config not found")
+)
+
+type File struct {
+	Github Github `yaml:"github"`
+}
+
+type Github struct {
+	Token string `yaml:"token"`
+}
+
+func ParseFromFile() (*File, error) {
+	return parseFromFile(configFile)
+}
+
+func parseFromFile(configFile string) (*File, error) {
+	f, err := os.OpenFile(configFile, os.O_RDONLY, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+
+	defer f.Close()
+
+	var c File
+
+	err = yaml.NewDecoder(f).Decode(&c)
+	if err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+
+	return &c, nil
+}
+
+func (c *File) WriteToFile() error {
+	return c.writeToFile(configFile)
+}
+
+func (c *File) writeToFile(configFile string) error {
+	f, err := os.OpenFile(configFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+
+	defer f.Close()
+
+	err = yaml.NewEncoder(f).Encode(c)
+	if err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+
+	return nil
+}
+
+func WithConfig(ctx context.Context, configFile string) context.Context {
+	ctx, cancel := context.WithCancelCause(ctx)
+
+	c, err := ParseFromFile()
+	if err != nil {
+		cancel(err)
+		return nil
+	}
+
+	return context.WithValue(ctx, ctxKeyConfig, c)
+}
+
+func ConfigFromContext(ctx context.Context) (*File, error) {
+	c, ok := ctx.Value(ctxKeyConfig).(*File)
+	if !ok {
+		return nil, ErrConfigNotFound
+	}
+
+	return c, nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -31,9 +33,9 @@ func ParseFromFile() (*File, error) {
 }
 
 func parseFromFile(configFile string) (*File, error) {
-	f, err := os.OpenFile(configFile, os.O_RDONLY, 0600)
+	f, err := os.OpenFile(configFile, os.O_CREATE|os.O_RDONLY, 0600)
 	if err != nil {
-		return nil, fmt.Errorf("parse: %w", err)
+		return nil, fmt.Errorf("parse: open: %w", err)
 	}
 
 	defer f.Close()
@@ -41,8 +43,8 @@ func parseFromFile(configFile string) (*File, error) {
 	var c File
 
 	err = yaml.NewDecoder(f).Decode(&c)
-	if err != nil {
-		return nil, fmt.Errorf("parse: %w", err)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("parse: decode: %w", err)
 	}
 
 	return &c, nil

--- a/config/path.go
+++ b/config/path.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+)
+
+const (
+	defaultConfigFile    = "config.yml"
+	defaultConfigBaseDir = ".config/concord/"
+
+	configDirMask  = 0700
+	configFileMask = 0600
+)
+
+var (
+	ErrTooPermissive = errors.New("permissions too permissive")
+)
+
+func GetConfigFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("config: home: %w", err)
+	}
+
+	dir := path.Join(home, defaultConfigBaseDir)
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("config: dir: %w", err)
+		}
+
+		err = os.MkdirAll(dir, configDirMask)
+		if err != nil {
+			return "", fmt.Errorf("config: mkdir: %w", err)
+		}
+
+		info, _ = os.Stat(dir)
+	}
+
+	if info.Mode().Perm() != configDirMask {
+		return "", fmt.Errorf("config: dir mask: %w", ErrTooPermissive)
+	}
+
+	f := path.Join(dir, defaultConfigFile)
+
+	info, err = os.Stat(f)
+	if err != nil && !os.IsNotExist(err) {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("config: file: %w", err)
+		}
+	}
+
+	if info != nil && info.Mode().Perm() != configFileMask {
+		return "", fmt.Errorf("config: file mask: %w", ErrTooPermissive)
+	}
+
+	return f, nil
+}


### PR DESCRIPTION
- start of auth command
- switch flags around for reauth
- need more scopes
- parsing and accessing config
- deal with error correctly
- create config if it doesn't exist when trying to read
- keeping real config files out of the repo
- handle permissions and the config better
- add check for empty token
- set token from config or override from env
